### PR TITLE
Fix bloom filter fallback and document demo usage

### DIFF
--- a/repo/README.md
+++ b/repo/README.md
@@ -33,23 +33,29 @@ The worker applies very cheap bit-plane masks and GLV/negation-derived tags befo
    python3 -m pip install -r requirements.txt
    ```
 
-2. **Create a Bloom filter** (using sample targets)
+2. *(Optional but recommended)* **Install KSOLVER-X in editable mode** so the
+   CLI entry points are available anywhere on your system:
+   ```bash
+   python3 -m pip install -e .
+   ```
+
+3. **Create a Bloom filter** (using sample targets)
    ```bash
    python3 -m cli.trap_tools build-bloom --csv tests/data/sample_targets.json --out bloom.dat --m-bits 20 --k-hashes 4
    ```
 
-3. **Generate demo traps**
+4. **Generate demo traps**
    ```bash
    python3 -m cli.trap_tools generate --out-dir traps_out --total-traps 1024 --bucket-log2 10 --base 0x1 --stride 2
    python3 -m cli.trap_tools index --traps-dir traps_out --shard-bits 8
    ```
 
-4. **Schedule lanes**
+5. **Schedule lanes**
    ```bash
    python3 -m cli.crt_tools schedule --L 0 --U 0x100000 --bits-per-mod 8 --mods 3 --workers 1 --lanes-per-worker 4 --out lanes.csv
    ```
 
-5. **Run a worker** (toy configuration that locates the known Genesis target)
+6. **Run a worker** (toy configuration that locates the known Genesis target)
    ```bash
    python3 -m cli.run_worker \
        --backend coincurve \
@@ -62,6 +68,74 @@ The worker applies very cheap bit-plane masks and GLV/negation-derived tags befo
    ```
 
 The worker prints progress metrics and writes candidate hits to `SAVES.TXT`. The demo operates on a 40-bit toy range in `scripts/demo_small_range.sh`.
+
+## Usage
+
+### End-to-end demo
+
+A complete toy pipeline is available via:
+
+```bash
+make run-demo
+```
+
+This script wires together trap generation, index creation, Bloom filter
+building and a single worker pass. It automatically exports the repository's
+`src` directory on `PYTHONPATH`, so you can run it directly from the source tree
+without first installing the package.
+
+Artifacts are written to the repository root:
+
+* `demo_traps/` – generated trap shards.
+* `demo_lanes.csv` – CRT lane schedule for worker `0`.
+* `demo_bloom.dat` – memory-mapped Bloom filter populated from
+  `tests/data/sample_targets.json`.
+* `demo_saves.txt` – candidate scalars that passed the verification stage.
+* `demo_metrics.jsonl` – periodic worker metrics in JSON lines format.
+
+### Manual invocation
+
+The CLI modules can be called individually once dependencies are installed:
+
+```bash
+python3 -m cli.trap_tools generate --help
+python3 -m cli.trap_tools index --help
+python3 -m cli.trap_tools build-bloom --help
+python3 -m cli.crt_tools schedule --help
+python3 -m cli.run_worker --help
+python3 -m cli.run_controller --help
+```
+
+Each command prints its supported arguments. To run the pipeline manually from
+the source tree without installing the package, prepend `PYTHONPATH=src` to the
+invocation, for example:
+
+```bash
+PYTHONPATH=src python3 -m cli.run_worker --help
+```
+
+## Low-value target example
+
+The repository ships with a low-difficulty test target representing the Bitcoin
+Genesis address RIPEMD-160 hash: `751e76e8199196d454941c45d1b3a323f1433bd6`. It
+is stored in `tests/data/sample_targets.json` and used by the demo pipeline.
+
+To probe the value explicitly with a worker, point the Bloom filter and target
+flags at the JSON file:
+
+```bash
+PYTHONPATH=src python3 -m cli.run_worker \
+    --backend coincurve --seed 1337 --r 8 --base 1 \
+    --lanes-csv demo_lanes.csv --worker-id 0 \
+    --traps-dir demo_traps --bucket-hint-bits 8 \
+    --bloom demo_bloom.dat --m-bits 20 --k-hashes 4 --mapped-size $((1<<20)) \
+    --target-rmd 751e76e8199196d454941c45d1b3a323f1433bd6 \
+    --steps-per-batch 1000 --verbose
+```
+
+The worker reports any matches it observes and appends successful scalars to
+`demo_saves.txt`, allowing you to sanity-check end-to-end behaviour against a
+known low-value target before launching larger jobs.
 
 ## CLI overview
 

--- a/repo/scripts/demo_small_range.sh
+++ b/repo/scripts/demo_small_range.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT=$(dirname "$0")/..
 cd "$ROOT"
 
+# Ensure the in-tree "src" package directory is on PYTHONPATH so ``python -m``
+# can resolve the cli.* entrypoints without requiring an editable install.
+export PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
 TRAPS_DIR="demo_traps"
 LANES="demo_lanes.csv"
 BLOOM="demo_bloom.dat"

--- a/repo/src/core/bloom.py
+++ b/repo/src/core/bloom.py
@@ -9,8 +9,86 @@ import mmap
 from collections.abc import Iterable
 from pathlib import Path
 
-from murmurhash3 import murmurhash3_x86_32
 from xxhash import xxh64
+
+try:  # pragma: no cover - exercised in fallback tests
+    from murmurhash3 import murmurhash3_x86_32 as _murmurhash3_x86_32_native
+except ModuleNotFoundError:  # pragma: no cover - handled by runtime fallback
+    _murmurhash3_x86_32_native = None
+
+
+def _rotl32(x: int, r: int) -> int:
+    """Rotate a 32-bit integer left by ``r`` bits."""
+
+    x &= 0xFFFFFFFF
+    return ((x << r) & 0xFFFFFFFF) | (x >> (32 - r))
+
+
+def _murmurhash3_x86_32_fallback(
+    data: bytes | bytearray | memoryview, seed: int = 0, *, signed: bool = False
+) -> int:
+    """Pure-Python MurmurHash3 implementation used when the C extension is absent."""
+
+    if isinstance(data, str):  # defensive: callers always pass bytes
+        data = data.encode("utf8")
+    view = memoryview(bytes(data))
+    length = len(view)
+
+    c1 = 0xCC9E2D51
+    c2 = 0x1B873593
+    h1 = seed & 0xFFFFFFFF
+
+    # Body
+    nblocks = length // 4
+    for offset in range(0, nblocks * 4, 4):
+        k1 = (
+            view[offset]
+            | (view[offset + 1] << 8)
+            | (view[offset + 2] << 16)
+            | (view[offset + 3] << 24)
+        )
+        k1 = (k1 * c1) & 0xFFFFFFFF
+        k1 = _rotl32(k1, 15)
+        k1 = (k1 * c2) & 0xFFFFFFFF
+
+        h1 ^= k1
+        h1 = _rotl32(h1, 13)
+        h1 = (h1 * 5 + 0xE6546B64) & 0xFFFFFFFF
+
+    # Tail
+    k1 = 0
+    tail = view[nblocks * 4 :]
+    if len(tail) >= 3:
+        k1 ^= tail[2] << 16
+    if len(tail) >= 2:
+        k1 ^= tail[1] << 8
+    if len(tail) >= 1:
+        k1 ^= tail[0]
+        k1 = (k1 * c1) & 0xFFFFFFFF
+        k1 = _rotl32(k1, 15)
+        k1 = (k1 * c2) & 0xFFFFFFFF
+        h1 ^= k1
+
+    # Finalisation
+    h1 ^= length
+    h1 &= 0xFFFFFFFF
+    h1 ^= h1 >> 16
+    h1 = (h1 * 0x85EBCA6B) & 0xFFFFFFFF
+    h1 ^= h1 >> 13
+    h1 = (h1 * 0xC2B2AE35) & 0xFFFFFFFF
+    h1 ^= h1 >> 16
+
+    if signed and h1 & 0x80000000:
+        return h1 - (1 << 32)
+    return h1
+
+
+def _murmurhash3_x86_32(data: bytes, seed: int = 0, *, signed: bool = False) -> int:
+    """Dispatch to the native MurmurHash3 or fallback implementation."""
+
+    if _murmurhash3_x86_32_native is not None:
+        return _murmurhash3_x86_32_native(data, seed, signed=signed)
+    return _murmurhash3_x86_32_fallback(data, seed=seed, signed=signed)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +115,10 @@ class MMapBloom:
             with path.open("wb") as fh:
                 fh.truncate(mapped_size)
         self._fh = path.open("r+b")
+        current_size = self._fh.seek(0, 2)
+        if current_size < mapped_size:
+            self._fh.truncate(mapped_size)
+        self._fh.seek(0)
         self._mm = mmap.mmap(self._fh.fileno(), mapped_size)
         logger.info(
             "bloom_open",
@@ -56,7 +138,7 @@ class MMapBloom:
 
     def _hashes(self, data: bytes) -> Iterable[int]:
         h1 = xxh64(data).intdigest()
-        h2 = murmurhash3_x86_32(data, 0, signed=False)
+        h2 = _murmurhash3_x86_32(data, 0, signed=False)
         for i in range(self.k_hashes):
             yield (h1 + i * h2) % self.m_bits
 

--- a/repo/tests/test_bloom.py
+++ b/repo/tests/test_bloom.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+
+from core import bloom
+
+
+def test_murmurhash3_fallback_known_vectors(monkeypatch) -> None:
+    """Ensure the pure Python fallback matches reference values."""
+
+    monkeypatch.setattr(bloom, "_murmurhash3_x86_32_native", None)
+    assert bloom._murmurhash3_x86_32(b"hello", seed=0, signed=False) == 0x248BFA47
+    assert bloom._murmurhash3_x86_32(b"", seed=0, signed=False) == 0x0
+    assert bloom._murmurhash3_x86_32(b"abc", seed=123, signed=False) == 0x1B7C6698
+
+
+def test_build_bloom_from_json(tmp_path, monkeypatch) -> None:
+    """Building a Bloom filter from JSON works even without the C extension."""
+
+    monkeypatch.setattr(bloom, "_murmurhash3_x86_32_native", None)
+    targets = [
+        "751e76e8199196d454941c45d1b3a323f1433bd6",
+        "0000000000000000000000000000000000000001",
+    ]
+    json_path = tmp_path / "targets.json"
+    json_path.write_text(json.dumps(targets), encoding="utf8")
+    bloom_path = tmp_path / "bloom.dat"
+
+    bloom.build_bloom_from_csv(json_path, bloom_path, m_bits=64, k_hashes=3)
+
+    with bloom.MMapBloom(bloom_path, m_bits=64, k_hashes=3) as filter_:
+        for target in targets:
+            assert filter_.contains(bytes.fromhex(target))
+        assert not filter_.contains(bytes.fromhex("ffffffffffffffffffffffffffffffffffffffff"))
+
+
+def test_bloom_reopen_with_larger_mapping(tmp_path, monkeypatch) -> None:
+    """Opening an existing Bloom filter with a larger mapping size extends the file."""
+
+    monkeypatch.setattr(bloom, "_murmurhash3_x86_32_native", None)
+    bloom_path = tmp_path / "filter.dat"
+    with bloom.MMapBloom(bloom_path, m_bits=32, k_hashes=2) as filter_:
+        filter_.add(b"abc")
+
+    # Reopen with a larger mapping size; this previously raised ValueError.
+    with bloom.MMapBloom(bloom_path, m_bits=32, k_hashes=2, mapped_size=1 << 12) as filter_:
+        assert filter_.contains(b"abc")


### PR DESCRIPTION
## Summary
- add a pure-Python MurmurHash3 fallback and ensure Bloom filters reopen with larger mappings
- cover the Bloom filter utilities with regression tests
- document the demo workflow, expose the low-value target, and make the demo script self-contained

## Testing
- pytest
- bash scripts/demo_small_range.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce2e31acfc832eac075153dd7b9b73