### PR TITLE
Add dedupe-aware trap index build with metadata

### DIFF
--- a/repo/src/cli/trap_tools.py
+++ b/repo/src/cli/trap_tools.py
@@ -41,6 +41,11 @@ def main(argv: list[str] | None = None) -> int:
     idx = sub.add_parser("index", help="Build trap shard index")
     idx.add_argument("--traps-dir", type=Path, required=True)
     idx.add_argument("--shard-bits", type=int, default=12)
+    idx.add_argument(
+        "--dedupe",
+        action="store_true",
+        help="Skip duplicate trap anchors when building the shard index",
+    )
 
     bloom_cmd = sub.add_parser("build-bloom", help="Build a Bloom filter from CSV")
     bloom_cmd.add_argument("--csv", type=Path, required=True)
@@ -64,7 +69,7 @@ def main(argv: list[str] | None = None) -> int:
             args.jobs,
         )
     elif args.cmd == "index":
-        build_sharded_index(args.traps_dir, args.shard_bits)
+        build_sharded_index(args.traps_dir, args.shard_bits, dedupe=args.dedupe)
     elif args.cmd == "build-bloom":
         build_bloom_from_csv(args.csv, args.out, args.m_bits, args.k_hashes)
     else:  # pragma: no cover

--- a/repo/src/traps/trap_index.py
+++ b/repo/src/traps/trap_index.py
@@ -18,12 +18,33 @@ logger = logging.getLogger(__name__)
 # - probe_tag1
 
 
-def build_sharded_index(traps_dir: Path, shard_bits: int) -> None:
-    """Build text-based shard files for trap lookup."""
+def build_sharded_index(
+    traps_dir: Path, shard_bits: int, *, dedupe: bool = False
+) -> None:
+    """Build text-based shard files for trap lookup.
+
+    Parameters
+    ----------
+    traps_dir:
+        Directory containing ``traps_*.bin`` files.
+    shard_bits:
+        Number of high-order tag bits used to form the shard identifier.
+    dedupe:
+        When ``True`` duplicate trap records (matching tag, bucket metadata and
+        anchor fingerprint) are skipped while constructing the index. Dedupe is
+        disabled by default to preserve legacy behaviour.
+    """
 
     index_dir = traps_dir / "index"
     index_dir.mkdir(parents=True, exist_ok=True)
     shard_maps: dict[int, list[tuple[int, str, int]]] = {}
+    total_records = 0
+    unique_records = 0
+    duplicates_dropped = 0
+    # Using a ``set`` of tuples keeps the dedupe logic deterministic while
+    # remaining reasonably compact compared to storing the original anchor.
+    seen_records: set[tuple[int, int, int, int]] = set()
+
     for trap_file in sorted(traps_dir.glob("traps_*.bin")):
         with trap_file.open("rb") as fh:
             offset = 0
@@ -31,18 +52,48 @@ def build_sharded_index(traps_dir: Path, shard_bits: int) -> None:
                 data = fh.read(RECORD_STRUCT.size)
                 if not data:
                     break
-                _, _, tag1, _, _ = RECORD_STRUCT.unpack(data)
-                shard = tag1 >> (64 - shard_bits)
+                total_records += 1
+                bucket_bytes, bucket_log2, tag1, tag2, _anchor = RECORD_STRUCT.unpack(data)
+                bucket_start = int.from_bytes(bucket_bytes, "big")
+                record_key = (tag1, bucket_start, bucket_log2, tag2)
+                if dedupe:
+                    if record_key in seen_records:
+                        duplicates_dropped += 1
+                        offset += RECORD_STRUCT.size
+                        continue
+                    seen_records.add(record_key)
+                unique_records += 1
+                shard = tag1 >> max(0, 64 - shard_bits)
                 shard_maps.setdefault(shard, []).append((tag1, trap_file.name, offset))
                 offset += RECORD_STRUCT.size
+
     for shard, rows in shard_maps.items():
+        rows.sort(key=lambda row: (row[0], row[1], row[2]))
         shard_path = index_dir / f"shard_{shard:04x}.idx"
         with shard_path.open("w", encoding="utf8") as fh:
             for tag1, file_name, offset in rows:
                 fh.write(f"{tag1:016x},{file_name},{offset}\n")
-    meta = {"shard_bits": shard_bits}
+
+    meta = {
+        "shard_bits": shard_bits,
+        "total_records": total_records,
+        "unique_records": unique_records,
+        "duplicates_dropped": duplicates_dropped,
+        "dedupe": dedupe,
+        "shards": {
+            f"{shard:04x}": len(rows) for shard, rows in sorted(shard_maps.items())
+        },
+    }
     (index_dir / "meta.json").write_text(json.dumps(meta), encoding="utf8")
-    logger.info("trap_index_built", extra={"shards": len(shard_maps), "shard_bits": shard_bits})
+    logger.info(
+        "trap_index_built",
+        extra={
+            "shards": len(shard_maps),
+            "shard_bits": shard_bits,
+            "total_records": total_records,
+            "duplicates_dropped": duplicates_dropped,
+        },
+    )
 
 
 def open_sharded_index(traps_dir: Path) -> dict[str, object]:

--- a/repo/src/traps/trapgen.py
+++ b/repo/src/traps/trapgen.py
@@ -102,12 +102,12 @@ def generate_traps(
         write_trap_file(path, entries)
 
 
-def build_index(out_dir: Path, shard_bits: int = 12) -> None:
+def build_index(out_dir: Path, shard_bits: int = 12, *, dedupe: bool = False) -> None:
     """Build a sharded index alongside the generated traps."""
 
     from .trap_index import build_sharded_index
 
-    build_sharded_index(out_dir, shard_bits)
+    build_sharded_index(out_dir, shard_bits, dedupe=dedupe)
 
 
 __all__ = [

--- a/repo/tests/test_traps.py
+++ b/repo/tests/test_traps.py
@@ -1,3 +1,5 @@
+import json
+
 from core.secp_backend import scalar_to_pubkey_compressed
 from traps import trapgen
 from traps.trap_index import build_sharded_index, open_sharded_index, probe_tag1
@@ -23,3 +25,35 @@ def test_trap_generation_and_index(tmp_path):
     tag1 = trapgen.fingerprint64(pub)
     locations = probe_tag1(index, tag1)
     assert locations
+
+
+def test_index_dedupe_and_metadata(tmp_path):
+    out_dir = tmp_path / "traps"
+    out_dir.mkdir()
+
+    entry_a = trapgen.trap_entry(1, bucket_log2=4, backend="coincurve")
+    entry_b = trapgen.trap_entry(3, bucket_log2=4, backend="coincurve")
+
+    trapgen.write_trap_file(out_dir / "traps_0000.bin", [entry_b, entry_a, entry_a])
+
+    build_sharded_index(out_dir, shard_bits=4, dedupe=True)
+
+    index_dir = out_dir / "index"
+    meta = json.loads((index_dir / "meta.json").read_text(encoding="utf8"))
+    assert meta["dedupe"] is True
+    assert meta["total_records"] == 3
+    assert meta["unique_records"] == 2
+    assert meta["duplicates_dropped"] == 1
+    assert meta["shards"]
+
+    shard_file = next(index_dir.glob("shard_*.idx"))
+    tags = []
+    with shard_file.open("r", encoding="utf8") as fh:
+        for line in fh:
+            tag_hex, *_ = line.strip().split(",")
+            tags.append(int(tag_hex, 16))
+    assert tags == sorted(tags)
+
+    index = open_sharded_index(out_dir)
+    assert probe_tag1(index, entry_a["tag1"])  # dedupe keeps one location
+    assert probe_tag1(index, entry_b["tag1"])  # unique entry preserved


### PR DESCRIPTION
## Summary
- add an optional dedupe flag to trap index building, with sorted output and richer metadata
- expose the dedupe option from the CLI and trapgen helper
- extend tests to cover index metadata, dedupe behaviour, and deterministic shard ordering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d139845f08832ea27b524293e8a4ce