### PR TITLE
Fix Makefile command indentation and add help target

### DIFF
--- a/repo/Makefile
+++ b/repo/Makefile
@@ -1,32 +1,38 @@
 PYTHON?=python3
 PIP?=$(PYTHON) -m pip
 
-.PHONY: install lint format test run-demo build-bloom gen-traps schedule worker
+.DEFAULT_GOAL := help
+
+.PHONY: help install lint format test run-demo build-bloom gen-traps schedule worker
+
+help:
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z0-9_-]+:' Makefile | sed 's/:.*//' | grep -v '^help$$' | xargs -n1 echo ' -'
 
 install:
-$(PIP) install -r requirements.txt
+	$(PIP) install -r requirements.txt
 
 lint:
-ruff check src tests
+	ruff check src tests
 
 format:
-ruff check --select I --fix src tests
-ruff format src tests
+	ruff check --select I --fix src tests
+	ruff format src tests
 
 test:
-pytest
+	pytest
 
 run-demo:
-bash scripts/demo_small_range.sh
+	bash scripts/demo_small_range.sh
 
 build-bloom:
-$(PYTHON) -m cli.trap_tools build-bloom
+	$(PYTHON) -m cli.trap_tools build-bloom
 
 gen-traps:
-$(PYTHON) -m cli.trap_tools generate
+	$(PYTHON) -m cli.trap_tools generate
 
 schedule:
-$(PYTHON) -m cli.crt_tools schedule
+	$(PYTHON) -m cli.crt_tools schedule
 
 worker:
-$(PYTHON) -m cli.run_worker
+	$(PYTHON) -m cli.run_worker


### PR DESCRIPTION
## Summary
- add a default `help` goal so running `make` no longer fails and lists the available targets
- ensure each Makefile command uses tab indentation so the targets execute correctly

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68d13c533058832ea7153b791f43b38f