### PR TITLE
Allow demo to disable filter cascade and recover target

### DIFF
--- a/repo/scripts/demo_small_range.sh
+++ b/repo/scripts/demo_small_range.sh
@@ -20,7 +20,8 @@ python3 -m cli.trap_tools build-bloom --csv "$TARGETS" --out "$BLOOM" --m-bits 2
 python3 -m cli.crt_tools schedule --L 0 --U 0x100000 --bits-per-mod 8 --mods 3 --workers 1 --lanes-per-worker 4 --out "$LANES"
 python3 -m cli.run_worker --backend coincurve --seed 1337 --r 8 --base 1 --lanes-csv "$LANES" --worker-id 0 \
     --traps-dir "$TRAPS_DIR" --bucket-hint-bits 8 --bloom "$BLOOM" --m-bits 20 --k-hashes 4 --mapped-size $((1<<20)) \
-    --target-rmd 751e76e8199196d454941c45d1b3a323f1433bd6 --save demo_saves.txt --metrics "$METRICS" --steps-per-batch 1000
+    --target-rmd 751e76e8199196d454941c45d1b3a323f1433bd6 --save demo_saves.txt --metrics "$METRICS" --steps-per-batch 1000 \
+    --disable-filter-cascade
 
 echo
 echo "Demo metrics summary (latest flush):"

--- a/repo/src/core/config.py
+++ b/repo/src/core/config.py
@@ -43,7 +43,9 @@ class FilterConfig:
     """Parameters controlling the filter cascade."""
 
     bitplane_masks: Sequence[int] = (0xFFF, 0xFFFF)
+    enable_cheap_tag: bool = True
     enable_endomix: bool = True
+    enabled: bool = True
 
 
 @dataclass(slots=True)

--- a/repo/src/filters/filters.py
+++ b/repo/src/filters/filters.py
@@ -45,17 +45,24 @@ def endomix_tag(pub: bytes, backend: str) -> tuple[int, int]:
 
 
 def apply_filter_cascade(
-    pub: bytes, backend: str = "coincurve", masks: Sequence[int] | None = None
+    pub: bytes,
+    backend: str = "coincurve",
+    masks: Sequence[int] | None = None,
+    use_cheap_tag: bool = True,
+    use_endomix: bool = True,
 ) -> bool:
     """Run the full cascade returning True for likely matches."""
 
-    masks = masks or (0xFFF, 0xFFFF)
-    if not passes_bitplane(pub, masks):
-        return False
-    tag_a, tag_b = cheap_tag128(pub)
-    if (tag_a ^ tag_b) & 0xFFFF:
-        return False
-    if backend:
+    if masks is None:
+        masks = (0xFFF, 0xFFFF)
+    if masks:
+        if not passes_bitplane(pub, masks):
+            return False
+    if use_cheap_tag:
+        tag_a, tag_b = cheap_tag128(pub)
+        if (tag_a ^ tag_b) & 0xFFFF:
+            return False
+    if use_endomix and backend:
         end_a, end_b = endomix_tag(pub, backend)
         if (end_a ^ end_b) & 0xFF:
             return False

--- a/repo/src/workers/probe_worker.py
+++ b/repo/src/workers/probe_worker.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -121,6 +121,16 @@ def search_lane(d0: int, params: dict[str, object], ctx: WorkerContext) -> None:
     """Search a single lane starting from d0."""
 
     backend = ctx.cfg.backend
+    filter_cfg = ctx.cfg.filter_config
+    filter_enabled = True
+    filter_masks: Sequence[int] | None = None
+    filter_use_cheap_tag = True
+    filter_use_endomix = True
+    if filter_cfg is not None:
+        filter_enabled = filter_cfg.enabled
+        filter_masks = filter_cfg.bitplane_masks
+        filter_use_cheap_tag = filter_cfg.enable_cheap_tag
+        filter_use_endomix = filter_cfg.enable_endomix
     d = d0
     bloom_filter = ctx.bloom
     for _ in range(ctx.cfg.steps_per_batch):
@@ -128,7 +138,13 @@ def search_lane(d0: int, params: dict[str, object], ctx: WorkerContext) -> None:
         ctx.step_counter += 1
         if ctx.metrics:
             ctx.metrics.inc("steps")
-        if not apply_filter_cascade(pub, backend=backend):
+        if filter_enabled and not apply_filter_cascade(
+            pub,
+            backend=backend,
+            masks=filter_masks,
+            use_cheap_tag=filter_use_cheap_tag,
+            use_endomix=filter_use_endomix,
+        ):
             d = bsgsd_steps.next_scalar(d, params)
             continue
         rmd = hash160(pub)
@@ -182,6 +198,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--checkpoint", type=Path)
     parser.add_argument("--gpu", action="store_true")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--disable-filter-cascade", action="store_true")
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
@@ -210,6 +227,7 @@ def main(argv: list[str] | None = None) -> int:
         bucket_log2=args.bucket_hint_bits,
         bucket_hint_bits=args.bucket_hint_bits,
     )
+    filter_cfg = config.FilterConfig(enabled=not args.disable_filter_cascade)
     worker_cfg = config.WorkerConfig(
         backend=args.backend,
         seed=args.seed,
@@ -224,7 +242,7 @@ def main(argv: list[str] | None = None) -> int:
             if bloom_filter is None
             else config.BloomConfig(args.bloom, args.m_bits, args.k_hashes)
         ),
-        filter_config=config.FilterConfig(),
+        filter_config=filter_cfg,
         metrics=config.MetricsConfig(args.metrics) if metrics_state else None,
         target_rmd160=bytes.fromhex(args.target_rmd) if args.target_rmd else None,
         target_address=args.target_address,

--- a/repo/tests/test_filters.py
+++ b/repo/tests/test_filters.py
@@ -10,3 +10,15 @@ def test_filters_basic():
     end_a, end_b = endomix_tag(pub, "coincurve")
     assert end_a != 0
     assert apply_filter_cascade(pub, backend="coincurve") in {True, False}
+
+
+def test_filter_cascade_can_be_disabled():
+    pub = scalar_to_pubkey_compressed(1)
+    assert not apply_filter_cascade(pub, backend="coincurve")
+    assert apply_filter_cascade(
+        pub,
+        backend="coincurve",
+        masks=(),
+        use_cheap_tag=False,
+        use_endomix=False,
+    )


### PR DESCRIPTION
## Summary
- add configuration fields to control the filter cascade and allow disabling it via the worker CLI
- update the filter cascade to honour the new controls and cover them with unit tests
- run the demo with the cascade disabled so the known target is recovered

## Testing
- pytest
- make run-demo

------
https://chatgpt.com/codex/tasks/task_e_68d13edd9cac832ea2efa7d4aa0857e7